### PR TITLE
Add CodeMirror syntax highlighting and fixed-width fonts

### DIFF
--- a/application.js
+++ b/application.js
@@ -57,6 +57,7 @@ jQuery(function($){
 		else {
 			$.get(ajaxurl, {action:hash}, function(data){
 				$('#view_wrapper').append(data);
+				initialize_codemirror();
 			});
 		}
 		$('.active').removeClass('active');
@@ -64,6 +65,33 @@ jQuery(function($){
 	}
 	window.onhashchange = get_hash;
 
+	function initialize_codemirror() {
+		$('#view_wrapper')
+			// Include a data-ub-codemirror attribute to make it eligible for CodeMirror.
+			.find('[data-ub-codemirror]')
+			.each(function(index, element) {
+				var $element = $(element);
+
+				if ($element.data('ub-codemirror') === '1') {
+					// Already initialized.
+					return;
+				}
+
+				// Initialize CodeMirror instance.
+				var editor = wp.codeEditor.initialize($element);
+				$element.data('ub-codemirror', '1');
+
+				// Copy code back to <textarea> on change so it's submitted.
+				editor.codemirror.on('change', function () {
+					var value = editor.codemirror.getValue();
+					if (value !== $element.val()) {
+						$element.val(value).trigger('change');
+					}
+				});
+			});
+	}
+
 	get_hash();
+	initialize_codemirror();
 });
 var hash;

--- a/functions.php
+++ b/functions.php
@@ -53,7 +53,9 @@ if ( isset( $_POST['full'] ) ) {
 
 	if ( isset( $_POST['code'] ) ) {
 		if ( isset( $_POST['action'] ) ) {
-			$function = create_function( '$args', $_POST['code'] );
+			$function = function () {
+				eval( $_POST['code'] );
+			};
 			add_action( $_POST['action'], $function, 999, 999 );
 		} else {
 			if ( false === eval( $_POST['code'] ) )

--- a/functions.php
+++ b/functions.php
@@ -7,6 +7,15 @@ function ub_scripts() {
 	wp_enqueue_script( 'jquery' );
 	wp_enqueue_script( 'bootstrap', 'https://netdna.bootstrapcdn.com/twitter-bootstrap/2.2.1/js/bootstrap.min.js', array( 'jquery' ), '2.2.1', true );
 	wp_enqueue_script( 'application', get_template_directory_uri() . '/application.js', array( 'jquery', 'bootstrap' ), '1.1.0', true );
+	wp_enqueue_code_editor(
+		array(
+			'type'       => 'php',
+			'codemirror' => array(
+				'lineNumbers' => false,
+				'mode'        => 'text/x-php', // PHP mode with an implied `<?php`.
+			),
+		)
+	);
 }
 add_action( 'wp_enqueue_scripts', 'ub_scripts' );
 

--- a/functions.php
+++ b/functions.php
@@ -6,7 +6,7 @@ if ( !is_admin() || ( defined( 'DOING_AJAX') && DOING_AJAX ) )
 function ub_scripts() {
 	wp_enqueue_script( 'jquery' );
 	wp_enqueue_script( 'bootstrap', 'https://netdna.bootstrapcdn.com/twitter-bootstrap/2.2.1/js/bootstrap.min.js', array( 'jquery' ), '2.2.1', true );
-	wp_enqueue_script( 'application', get_template_directory_uri() . '/application.js', array( 'jquery', 'bootstrap' ), '1.1.0', true );
+	wp_enqueue_script( 'application', get_template_directory_uri() . '/application.js', array( 'jquery', 'bootstrap' ), '1.2.0', true );
 	wp_enqueue_code_editor(
 		array(
 			'type'       => 'php',

--- a/index.php
+++ b/index.php
@@ -7,7 +7,7 @@
 					<div class="control-group">
 						<label class="control-label" for="code">Any PHP entered here will be processed through a WordPress "short init" request</label>
 						<div class="controls">
-							<textarea name="code" rows="8" cols="40" class="span6"></textarea>
+							<textarea data-ub-codemirror name="code" rows="8" cols="40" class="span6"></textarea>
 						</div>
 					</div>
 					<div class="form-actions">

--- a/pages/benchmark.php
+++ b/pages/benchmark.php
@@ -12,20 +12,20 @@
 					</div>
 					<div class="control-group">
 						<label class="control-label" for="code_a">Environment (e.g. shared variables, functions, etc.)</label>
-						<div class="controls">
-							<textarea name="env" id="env" rows="4" cols="40" class="span6"></textarea>
+						<div class="controls codemirror-height-auto">
+							<textarea data-ub-codemirror name="env" id="env" rows="4" cols="40" class="span6"></textarea>
 						</div>
 					</div>
 					<div class="control-group">
 						<label class="control-label" for="code_a">Test A</label>
-						<div class="controls">
-							<textarea name="code_a" id="code_a" rows="8" cols="40" class="span6"></textarea>
+						<div class="controls codemirror-height-200">
+							<textarea data-ub-codemirror name="code_a" id="code_a" rows="8" cols="40" class="span6"></textarea>
 						</div>
 					</div>
 					<div class="control-group">
 						<label class="control-label" for="code_b">Test B</label>
-						<div class="controls">
-							<textarea name="code_b" id="code_b" rows="8" cols="40" class="span6"></textarea>
+						<div class="controls codemirror-height-200">
+							<textarea data-ub-codemirror name="code_b" id="code_b" rows="8" cols="40" class="span6"></textarea>
 						</div>
 					</div>
 					<div class="form-actions">

--- a/pages/printf.php
+++ b/pages/printf.php
@@ -5,7 +5,7 @@
 			<div class="control-group">
 				<label class="control-label" for="printf_format">Format</label>
 				<div class="controls">
-					<input type="text" name="printf_format" value="The %s ate %d %s!" id="printf_format" class="span3" />
+					<input type="text" name="printf_format" value="The %s ate %d %s!" id="printf_format" class="span3 monospace" />
 				</div>
 				<a href="#printfModal" role="button" class="btn" data-toggle="modal">Reference</a>
 			</div>
@@ -13,7 +13,7 @@
 			<div class="control-group">
 				<label class="control-label" for="printf_arguments">Arguments (one per line</label>
 				<div class="controls">
-					<textarea name="printf_arguments" id="printf_arguments" rows="4" class="span3"></textarea>
+					<textarea name="printf_arguments" id="printf_arguments" rows="4" class="span3 monospace"></textarea>
 				</div>
 			</div>
 

--- a/pages/regex.php
+++ b/pages/regex.php
@@ -6,14 +6,14 @@
 			<div class="control-group">
 				<label class="control-label" for="expression">Regex</label>
 				<div class="controls">
-					<textarea name="expression" id="expression" rows="3" cols="40" class="span6"></textarea>
+					<textarea name="expression" id="expression" rows="3" cols="40" class="span6 monospace"></textarea>
 					<p class="help-block">Don't forget to wrap your expression, e.g. /expression/</p>
 				</div>
 			</div>
 			<div class="control-group">
 				<label class="control-label" for="replace">Replace</label>
 				<div class="controls">
-					<textarea name="replace" id="replace" rows="3" cols="40" class="span6"></textarea>
+					<textarea name="replace" id="replace" rows="3" cols="40" class="span6 monospace"></textarea>
 				</div>
 			</div>
 			<div class="control-group">

--- a/pages/serialization.php
+++ b/pages/serialization.php
@@ -6,7 +6,7 @@
 			<div class="control-group">
 				<label class="control-label" for="serializee">String or Expression</label>
 				<div class="controls">
-					<textarea name="serializee" id="serializee" rows="3" cols="40" class="span6"></textarea>
+					<textarea name="serializee" id="serializee" rows="3" cols="40" class="span6 monospace"></textarea>
 					<p class="help-block">An expression to serialize can be any PHP that could be returned by a function, like array('foo','bar').</p>
 				</div>
 			</div>

--- a/pages/time.php
+++ b/pages/time.php
@@ -7,7 +7,7 @@
 			<div class="control-group">
 				<label class="control-label" for="date_format">Format</label>
 				<div class="controls">
-					<input type="text" name="date_format" value="Y-m-d H:i:s T" id="date_format" class="span3" />
+					<input type="text" name="date_format" value="Y-m-d H:i:s T" id="date_format" class="span3 monospace" />
 				</div>
 				<a href="#formatModal" role="button" class="btn" data-toggle="modal">Reference</a>
 			</div>
@@ -25,14 +25,14 @@
 			<div class="control-group">
 				<label class="control-label" for="timestamp">Timestamp</label>
 				<div class="controls">
-					<input type="text" name="timestamp" value="" id="timestamp" class="span3" />
+					<input type="text" name="timestamp" value="" id="timestamp" class="span3 monospace" />
 				</div>
 			</div>
 
 			<div class="control-group">
 				<label class="control-label" for="strtotime"><code>strtotime</code> string (assumed UTC unless the string incldues a timezone)</label>
 				<div class="controls">
-					<input type="text" name="strtotime" value="" id="strtotime" class="span3" />
+					<input type="text" name="strtotime" value="" id="strtotime" class="span3 monospace" />
 				</div>
 			</div>
 

--- a/pages/wordpress.php
+++ b/pages/wordpress.php
@@ -13,7 +13,7 @@
 					<div class="control-group">
 						<label class="control-label" for="code">Any PHP entered here will be run through a full pageload, not a "short init"</label>
 						<div class="controls">
-							<textarea name="code" rows="8" cols="40" class="span6"></textarea>
+							<textarea data-ub-codemirror name="code" rows="8" cols="40" class="span6"></textarea>
 						</div>
 					</div>
 					<div class="form-actions">

--- a/style.css
+++ b/style.css
@@ -16,3 +16,15 @@ pre.well {
 table pre {
 	white-space: pre;
 }
+.CodeMirror {
+	border: 1px solid #ddd;
+}
+.codemirror-height-auto .CodeMirror {
+	height: auto;
+}
+.codemirror-height-200 .CodeMirror {
+	height: 200px;
+}
+.monospace {
+	font-family: Monaco, Menlo, Consolas, "Courier New", monospace;
+}


### PR DESCRIPTION
Adds CodeMirror to the 'Home', 'Hook', and 'Benchmark' pages for PHP syntax highlighting. Adds fixed-width styles to most inputs on other pages.

Open to suggestions about how exactly this would work, but I'd love to not have variable-width fonts in the inputs somehow 😄 

Some TODOs for either now or later:

- [ ] See whether tabs can still be respected to jump to the submit button
- [ ] Try to style CodeMirror with a minimum height that also auto-expands